### PR TITLE
call commit on the Activity, not Application, in order to trigger sys…

### DIFF
--- a/PasswordAutofillSample.Android/AndroidAutofillManager.cs
+++ b/PasswordAutofillSample.Android/AndroidAutofillManager.cs
@@ -13,7 +13,7 @@ namespace PasswordAutofillSample.Droid
         {
             if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
             {
-                var manager = (AutofillManager)Application.Context.GetSystemService(Java.Lang.Class.FromType(typeof(AutofillManager)));
+                var manager = (AutofillManager)MainActivity.Current.GetSystemService(Java.Lang.Class.FromType(typeof(AutofillManager)));
                 manager.Commit();
             }
         }

--- a/PasswordAutofillSample.Android/MainActivity.cs
+++ b/PasswordAutofillSample.Android/MainActivity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.Runtime;
 using Android.Views;
@@ -12,6 +13,13 @@ namespace PasswordAutofillSample.Droid
     [Activity(Label = "PasswordAutofillSample", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
+        public static Context Current { get; private set; }
+
+        public MainActivity()
+        {
+            Current = this;
+        }
+
         protected override void OnCreate(Bundle savedInstanceState)
         {
             TabLayoutResource = Resource.Layout.Tabbar;


### PR DESCRIPTION
Application context has a different context than MainActivity and the sample didn't trigger the save password dialog when the `commit` is called. So in order to dialog to show we can use MainActivity as a context:

```
var manager = (AutofillManager)MainActivity.Current.GetSystemService(Java.Lang.Class.FromType(typeof(AutofillManager)));
manager.Commit();
```

And with a plugin like [CurrentActivityPlugin](https://github.com/jamesmontemagno/CurrentActivityPlugin) it would be even easier:

```
var manager = (AutofillManager)CrossCurrentActivity.Current.Activity.GetSystemService(Java.Lang.Class.FromType(typeof(AutofillManager)));
manager.Commit();
```

ps: [In accordance with the docs](https://developer.android.com/guide/topics/text/autofill-optimize#ensure), calling commit is usually not required but in case of Xamarin.Forms app, the navigation is implemented differently and no actual Activity is finished.

![android password autofill](https://user-images.githubusercontent.com/3697084/69186625-b0435e80-0acd-11ea-8a24-786bb523a49c.png)
